### PR TITLE
Clarify `How do I help receive?` for easier readability

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,7 +68,7 @@
                 If you're looking for meteorological radiosondes, try the regular
                 <a href="https://tracker.sondehub.org/" target="_blank" rel="noopener">SondeHub Tracker.</a>
 
-                <h4>How do I help receive?</h4>
+                <h4>How do I help to receive?</h4>
                 Information on receiving common telemetry formats is 
                 <a href="https://github.com/projecthorus/sondehub-amateur-tracker/wiki/Receiving-High-Altitude-Balloon-Telemetry" target="_blank" rel="noopener">available here.</a> 
                 <br/>


### PR DESCRIPTION
The question `How do I help receive?` in the home page is a bit difficult to parse at first without the full context of the website. My brain kept autocorrecting it as `How do I receive help?`.

This PR updates the question to `How do I help to receive?`.

Initial suggestion source: https://twitter.com/AlesandroOrtizR/status/1523160894703820802

I'm also okay with `How do I help to receive telemetry?`, which is a meld of my suggestion and this suggestion: https://twitter.com/vk5qi/status/1523161254546010112

Current:
![image](https://user-images.githubusercontent.com/1619599/167282263-4617d176-3c7c-4dd0-9297-e5cf69255d3e.png)

Proposed (updated in PR):
![image](https://user-images.githubusercontent.com/1619599/167282271-9fb6878e-5897-4378-af2e-2c57d6f3088c.png)

Great project, big fan! Makes me want to launch an amateur balloon without even knowing how to start. :)