### PR TITLE
Rework balloon shape

### DIFF
--- a/img/markers/balloon.svg
+++ b/img/markers/balloon.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100" height="200">
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="183">
   <!-- CSS style acts as container for the color variable. -->
   <style>
     :root {
@@ -40,16 +40,16 @@
     <ellipse cx="50" cy="154" rx="18" ry="7" fill="var(--dynamic-color)" 
       stroke="black" stroke-width="1"/>
   <!-- String down to payload -->
-  <line x1="50" y1="118" x2="50" y2="154" 
+  <line x1="50" y1="90" x2="50" y2="154" 
       stroke="black" stroke-width="1.5" filter="url(#linesWhiteShadow)"/>
   <!-- The balloon itself -->
   <path
-     d="M 50 118 H 47 V 115 
-    C 47 103, 2 88, 2 45
+     d="M 50 110 H 47 V 107 
+    C 47 95, 2 75, 2 45
     A 48 40 0 0 1 98 45
-    C 98 88, 53 103, 53 115
-    V 118
-    H 50 Z" 
+    C 98 75, 53 95, 53 107
+    V 110
+    H 50 Z"
     fill="url(#balloonGradient)" 
     stroke="black" stroke-width="1.5"
     fill-opacity="0.8"


### PR DESCRIPTION
Changed some of the values used in the shape of the curve of the balloon.

Also changed the SVG to be 100x183 instead of 100x200, this will match the as-used aspect ratio of [46x84] which is used in tracker.js when loading the balloon icon.

Happy to keep playing around with the dimensions as needed, but this subjectively seems to look better and more balloony.